### PR TITLE
Fix issue: IndexError: list index out of range

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -91,8 +91,8 @@ for f in files:
 
             locations += 1
 
-            lat = location['gps_coordinates'].split('/')[0]
-            lon = location['gps_coordinates'].split('/')[1]
+            lat= re.split('/|,',location['gps_coordinates'])[0]
+            lon= re.split('/|,',location['gps_coordinates'])[1]
 
             name_full = name
 


### PR DESCRIPTION
Some gps_coordinates in the json files have  ',' instead of '/' to separate latitude and longitude. This leads to the issue.

Handle this case.